### PR TITLE
[Feat/#35] 회원별 추천글 목록 조회 API 연동

### DIFF
--- a/app/src/main/java/com/example/resona/data/remote/api/PostApiService.kt
+++ b/app/src/main/java/com/example/resona/data/remote/api/PostApiService.kt
@@ -40,4 +40,12 @@ interface PostApiService {
     suspend fun toggleScrap(
         @Path("postId") postId: Long
     ): Response<BaseResponse<String>>
+
+    // 회원별 추천글 조회
+    @GET("posts/members/{writerId}")
+    suspend fun getOtherMemberPosts(
+        @Path("writerId") writerId: Long,
+        @Query("category") category: RecommendCategory?,
+        @Query("scene") scene: RecommendScene?
+    ): Response<BaseResponse<List<PostResponseDto>>>
 }

--- a/app/src/main/java/com/example/resona/data/repository/PostRepository.kt
+++ b/app/src/main/java/com/example/resona/data/repository/PostRepository.kt
@@ -115,4 +115,30 @@ class PostRepository @Inject constructor(
             ApiResult.Error(e)
         }
     }
+
+    /**
+     * 회원별 추천글 조회
+     */
+    suspend fun fetchOtherMemberPosts(
+        writerId: Long,
+        category: RecommendCategory?,
+        scene: RecommendScene?
+    ): ApiResult<List<PostResponseDto>> = withContext(Dispatchers.IO) {
+        try {
+            val response = apiService.getOtherMemberPosts(writerId, category, scene)
+            if (response.isSuccessful) {
+                response.body()?.let { baseResponse ->
+                    if (baseResponse.isSuccess) {
+                        ApiResult.Success(baseResponse.result ?: emptyList())
+                    } else {
+                        ApiResult.Error(Exception(baseResponse.message))
+                    }
+                } ?: ApiResult.Error(Exception("Empty body"))
+            } else {
+                ApiResult.Error(Exception("HTTP ${response.code()}"))
+            }
+        } catch (e: Exception) {
+            ApiResult.Error(e)
+        }
+    }
 }

--- a/app/src/main/java/com/example/resona/ui/my/OtherProfileFragment.kt
+++ b/app/src/main/java/com/example/resona/ui/my/OtherProfileFragment.kt
@@ -54,7 +54,7 @@ class OtherProfileFragment : Fragment(R.layout.fragment_mypage) {
                             putString("postType", "other")
                             putLong("targetMemberId", memberId)
                         }
-                        findNavController().navigate(R.id.action_to_postList, bundle)
+                        findNavController().navigate(R.id.action_otherProfile_to_postList, bundle)
                     }
                 }
             }

--- a/app/src/main/java/com/example/resona/ui/post/fragment/PostListFragment.kt
+++ b/app/src/main/java/com/example/resona/ui/post/fragment/PostListFragment.kt
@@ -35,7 +35,20 @@ class PostListFragment : Fragment(R.layout.fragment_post_list) {
         observeViewModel()
         setupFilterListeners()
 
-        viewModel.loadPosts()
+        // [추가] 전달받은 인자값에 따른 데이터 로드 분기
+        val postType = arguments?.getString("postType")
+        val targetId = arguments?.getLong("targetMemberId", -1L) ?: -1L
+
+        if (postType == "other" && targetId != -1L) {
+            // 1. 타인 프로필에서 넘어온 경우: 해당 사용자의 게시글만 로드
+            viewModel.loadOtherMemberPosts(targetId)
+
+            // 타인 글 목록일 때는 상단 필터바를 숨기거나 비활성화하고 싶다면 여기에 추가 로직 작성 가능
+            // 예: binding.layoutFilterBar.visibility = View.GONE
+        } else {
+            // 2. 일반적인 경우: 전체 게시글 로드
+            viewModel.loadPosts(selectedCategory, selectedScene)
+        }
     }
 
     private fun setupRecyclerView() {
@@ -53,6 +66,7 @@ class PostListFragment : Fragment(R.layout.fragment_post_list) {
     private fun observeViewModel() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.uiState.collect { state ->
+                // API 결과(state.posts)가 어댑터에 전달됨
                 postAdapter.updateData(state.posts)
             }
         }
@@ -87,7 +101,15 @@ class PostListFragment : Fragment(R.layout.fragment_post_list) {
     }
 
     private fun updateList() {
-        viewModel.loadPosts(selectedCategory, selectedScene)
+        val postType = arguments?.getString("postType")
+        val targetId = arguments?.getLong("targetMemberId", -1L) ?: -1L
+
+        if (postType == "other" && targetId != -1L) {
+            viewModel.loadOtherMemberPosts(targetId, selectedCategory, selectedScene)
+        } else {
+            // 일반 게시글 목록 조회
+            viewModel.loadPosts(selectedCategory, selectedScene)
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/resona/ui/post/viewmodel/PostViewModel.kt
+++ b/app/src/main/java/com/example/resona/ui/post/viewmodel/PostViewModel.kt
@@ -2,6 +2,7 @@ package com.example.resona.ui.post.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.resona.data.dto.PostResponseDto
 import com.example.resona.data.enums.RecommendCategory
 import com.example.resona.data.enums.RecommendScene
 import com.example.resona.data.remote.model.ApiResult
@@ -31,6 +32,25 @@ class PostViewModel @Inject constructor(
                 }
                 is ApiResult.Error -> {
                     _uiState.value = PostUiState(error = result.exception.message)
+                }
+                else -> Unit
+            }
+        }
+    }
+
+    fun loadOtherMemberPosts(
+        writerId: Long,
+        category: RecommendCategory? = null,
+        scene: RecommendScene? = null
+    ) {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true)
+            when (val result = repository.fetchOtherMemberPosts(writerId, category, scene)) {
+                is ApiResult.Success -> {
+                    _uiState.value = PostUiState(posts = result.data)
+                }
+                is ApiResult.Error -> {
+                    _uiState.value = _uiState.value.copy(isLoading = false, error = result.exception.message)
                 }
                 else -> Unit
             }


### PR DESCRIPTION
##  관련 이슈
- #35

##  과제 내용
> 이번 PR에서 작업한 주요 변경 사항을 요약해주세요.
- 회원별 추천글 목록 조회 API를 연동합니다.
- 타인 프로필에서 oo님이 추천한 글 버튼을 누르면 회원별 추천글 목록으로 이동합니다

##  셀프 체크리스트 (프론트엔드 컨벤션)
- [x] **들여쓰기**: 공백 4개를 준수하였나요?
- [x] **명명 규칙**: 클래스는 **PascalCase**, 변수/함수는 **camelCase**인가요?
- [x] **변수 선언**: 값이 변하지 않는 변수는 **val**로 선언했나요?
- [x] **개행**: 파일 마지막에 **빈 줄(EOL)**을 추가하였나요?
- [x] **리소스**: ID 명명 규칙(`타입_기능`)을 준수하였나요?

##  결과물 (선택)
> UI/UX 변경이 있는 경우 스크린샷을 첨부해주세요.

<img width="250" alt="image" src="https://github.com/user-attachments/assets/8d1b0ce7-09d2-4ff7-b8f1-29c185a6eaef" />
